### PR TITLE
Update python_version for 3.13

### DIFF
--- a/cylance.json
+++ b/cylance.json
@@ -11,7 +11,7 @@
     "publisher": "Splunk",
     "license": "Copyright (c) 2018-2025 Splunk Inc.",
     "app_version": "2.0.6",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "utctime_updated": "2022-08-16T17:04:06.000000Z",
     "package_name": "phantom_cylanceprotect",
     "main_module": "cylance_connector.py",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)